### PR TITLE
Remove ServerPilot.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,6 @@ Table of Contents
 
   * [pages.github.com](https://pages.github.com/) — Hosting static site directly from GitHub repository
   * [closeheat.com](https://closeheat.com/) — Development Environment in the Cloud for Static Websites with Free Hosting and GitHub integration. 1 free website with custom domain support
-  * [serverpilot.io](https://serverpilot.io/) ServerPilot, and we'll install everything you need to host PHP apps like WordPress. Unlimited servers, 1 SSH/SFTP user
   * [sourceforge.net](https://sourceforge.net/) — Find, Create and Publish Open Source software for free
   * [devport.co](http://devport.co/) — Turn GitHub projects, apps and websites into a personal developer portfolio
   * [netlify.com](https://www.netlify.com/) — Builds, deploy and hosts static site or app, free for 100 GB data and 100 GB/month bandwidth


### PR DESCRIPTION
As of July 10, 2018, [ServerPilot no longer offers a free version](https://serverpilot.io/blog/2018/06/08/pricing-changes).